### PR TITLE
fix tuple error for failing quickreply

### DIFF
--- a/config.py
+++ b/config.py
@@ -76,8 +76,8 @@ except Exception as e:
             'isFocus': False,
             'type': '',
             'name': '',
-        },
-        qqbot = False,
+        }
+        qqbot = False
 
 '''
 报文格式说明：


### PR DESCRIPTION
logs here:

```
qq2tg    | INFO:__main__:quickreply invoked
qq2tg    | ERROR:telegram.ext.dispatcher:An uncaught error was raised while processing the update
qq2tg    | Traceback (most recent call last):
qq2tg    |   File "/usr/local/lib/python3.7/site-packages/telegram/ext/dispatcher.py", line 279, in process_update
qq2tg    |     handler.handle_update(update, self)
qq2tg    |   File "/usr/local/lib/python3.7/site-packages/telegram/ext/messagehandler.py", line 169, in handle_update
qq2tg    |     return self.callback(dispatcher.bot, update, **optional_args)
qq2tg    |   File "tg.py", line 89, in quickreply
qq2tg    |     if tmp['isFocus']:
qq2tg    | TypeError: tuple indices must be integers or slices, not str
qq2tg    | INFO:root:<class 'config.store'>
qq2tg    | ERROR:telegram.ext.dispatcher:An uncaught error was raised while processing the update
qq2tg    | Traceback (most recent call last):
qq2tg    |   File "/usr/local/lib/python3.7/site-packages/telegram/ext/dispatcher.py", line 279, in process_update
qq2tg    |     handler.handle_update(update, self)
qq2tg    |   File "/usr/local/lib/python3.7/site-packages/telegram/ext/messagehandler.py", line 169, in handle_update
qq2tg    |     return self.callback(dispatcher.bot, update, **optional_args)
qq2tg    |   File "tg.py", line 122, in chatting
qq2tg    |     if tmp['isFocus']:
qq2tg    | TypeError: tuple indices must be integers or slices, not str
```

